### PR TITLE
bugfix:Fairyの_isControllableがfalseになったら即止まるように修正

### DIFF
--- a/Assets/MemoryTranser/Scripts/Game/Fairy/FairyCore.cs
+++ b/Assets/MemoryTranser/Scripts/Game/Fairy/FairyCore.cs
@@ -494,6 +494,7 @@ namespace MemoryTranser.Scripts.Game.Fairy {
             SeManager.I.Play(SEs.FairyAttackedByDesire);
             _isControllable = false;
             rb2D.velocity = Vector2.zero;
+            _inputWalkDirection = Vector2.zero;
             CurrentComboCount = 0;
             _myState = FairyState.Freeze;
 


### PR DESCRIPTION
OnMoveInput内で管理するとなぜか遅延が発生するので当たった瞬間に動きを止めるように変更しました。